### PR TITLE
Customize pre-release version template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Fix [#2](https://github.com/compulim/version-from-git/issues/2). Supports customizing pre-release, in [PR #3](https://github.com/compulim/version-from-git/pulls/3)
+- Fix [#2](https://github.com/compulim/version-from-git/issues/2). Supports customizing pre-release thru `--template`, in [PR #3](https://github.com/compulim/version-from-git/pulls/3)
 
 ## [1.0.0] - 2018-05-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Fix [#2](https://github.com/compulim/version-from-git/issues/2). Supports customize pre-release pattern, in [PR #3](https://github.com/compulim/version-from-git/pulls/3)
+
 ## [1.0.0] - 2018-05-18
 ### Added
 - Initial commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Fix [#2](https://github.com/compulim/version-from-git/issues/2). Supports customize pre-release pattern, in [PR #3](https://github.com/compulim/version-from-git/pulls/3)
+- Fix [#2](https://github.com/compulim/version-from-git/issues/2). Supports customizing pre-release, in [PR #3](https://github.com/compulim/version-from-git/pulls/3)
 
 ## [1.0.0] - 2018-05-18
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 We want to use `npm version` to bump to a customized version that contains both Git branch and commit hash.
 
-And use Travis CI to automatically publish the prerelease version to NPM, tagged using [`npm dist-tag`](https://docs.npmjs.com/cli/dist-tag).
+And use Travis CI to automatically publish the pre-release version to NPM, tagged using [`npm dist-tag`](https://docs.npmjs.com/cli/dist-tag).
 
-> Instead of using plus (+) to denote build information, we prefer period (.) for simpler escapes.
+> Instead of using plus (+) to denote build information, we prefer period (.) for simpler escapes. If you prefer the plus sign, you can [customize the pre-release version pattern](#customizing-pre-release-version-pattern).
 
 # How to use
 
-Run `npx version-from-git`, it will run `npm version 1.0.0-master+1a2b3c4`.
+Run `npx version-from-git`, it will run `npm version 1.0.0-master.1a2b3c4`.
 
 ```
   Usage: version-from-git [options]
@@ -38,6 +38,18 @@ Run `npx version-from-git`, it will run `npm version 1.0.0-master+1a2b3c4`.
 In Travis, when you push a tag (probably by `npm version 1.0.0` followed by `git push origin v1.0.0`), you may want to skip `version-from-git` from generating a pre-release tag.
 
 Run `npx version-from-git -t`, it will detect whether `TRAVIS_TAG` environment variable is present and skip.
+
+## Customizing pre-release version pattern
+
+You can customize the version pattern when tagging for pre-release versions.
+
+| Pattern name | Description                                                      | Sample                                     |
+|--------------|------------------------------------------------------------------|--------------------------------------------|
+| `branch`     | Branch name<br />In Travis, will use `process.env.TRAVIS_BRANCH` | `master`                                   |
+| `long`       | Git commit in long form                                          | `3807f9004867438c57a3e26f2073c33c458d4ef9` |
+| `short`      | Git commit in short form                                         | `3807f90`                                  |
+
+Default pattern is `branch.short`, which would produce `master.1a2b3c4`.
 
 # Contributions
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
   "keywords": [
     "branch",
     "bump",
+    "ci",
     "commit",
     "git",
+    "travis",
     "version"
   ],
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -11,13 +11,13 @@ const spawn = require('cross-spawn');
 const { log } = console;
 const ourPackageJSON = require(join(__dirname, '../package.json'));
 
-const DEFAULT_PATTERN = 'branch.short';
+const DEFAULT_TEMPLATE = 'branch.short';
 
 program
   .version(ourPackageJSON.version)
   .description(ourPackageJSON.description)
   .option('-p, --path <path>', 'path to package.json, default to current directory', process.cwd())
-  .option('--pattern <pattern>', 'pre-release version pattern', DEFAULT_PATTERN)
+  .option('--template <template>', 'pre-release version template', DEFAULT_TEMPLATE)
   .option('-t, --travis', 'run in Travis CI: skip when TRAVIS_TAG present')
   .option('-f, --force', 'run "npm version" with --force')
   .option('-m, --message <message>', 'run "npm version" with --message')
@@ -69,8 +69,7 @@ function main() {
   }
 
   const { version } = packageJSON;
-  const { pattern = DEFAULT_PATTERN } = program;
-  const preRelease = pattern.replace(/\w+/giu, name => {
+  const preRelease = (program.template || DEFAULT_TEMPLATE).replace(/\w+/giu, name => {
     switch (name) {
       case 'branch': return branch;
       case 'short': return short;
@@ -97,9 +96,9 @@ function main() {
 
   log(`Running ${ magenta(`npm ${ args.join(' ') }`) }`);
 
-  const result = spawn.sync('npm', args, { cwd, stdio: 'inherit' });
+  // const result = spawn.sync('npm', args, { cwd, stdio: 'inherit' });
 
-  process.exit(result);
+  // process.exit(result);
 }
 
 main();


### PR DESCRIPTION
> Fix #2.

## Description

Today, we do not allow developers to set their own pre-release version template.

Tomorrow, we will support through:
- If `--template` is not specified, will default to `branch.short`, which could be `master.1a2b3c4`
- If `--template` is specified
   - `--template branch+short` could be `master+1a2b3c4`
   - `--template short` could be `1a2b3c4`

> Copied from `README.md`

| Pattern name | Description                                                      | Sample                                     |
|--------------|------------------------------------------------------------------|--------------------------------------------|
| `branch`     | Branch name<br />In Travis, will use `process.env.TRAVIS_BRANCH` | `master`                                   |
| `long`       | Git commit in long form                                          | `3807f9004867438c57a3e26f2073c33c458d4ef9` |
| `short`      | Git commit in short form                                         | `3807f90`                                  |

## Changelog

### Added
- Fix [#2](https://github.com/compulim/version-from-git/issues/2). Supports customizing pre-release thru `--template`, in [PR #3](https://github.com/compulim/version-from-git/pulls/3)
