### PR TITLE
Fix process.exit call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,7 @@ function main() {
 
   const result = spawn.sync('npm', args, { cwd, stdio: 'inherit' });
 
-  process.exit(result);
+  process.exit(result.status);
 }
 
 main();


### PR DESCRIPTION
regarding the documentation, it expects an integer. the previous implementation didn't work with node@20 anymore

See: #16 